### PR TITLE
Docs: Use absolute paths

### DIFF
--- a/docs/CONTRIBUTING.MD
+++ b/docs/CONTRIBUTING.MD
@@ -118,4 +118,4 @@ For function contributions, each commit should contain one function match and wh
 
 Now it's time to PR. In the PR description, include links to the scratches for the matched functions:
 
-![image](./images/PR-example.png)
+![image](/docs/images/PR-example.png)

--- a/docs/DECOMPILATION.MD
+++ b/docs/DECOMPILATION.MD
@@ -25,7 +25,7 @@ In decompilation, these will manifest as errors:
   M2C_ERROR(/* unknown instruction: gpl 0x1 */);
 ```
 
-If you're decompiling a function and encounter these, then what you've found is a [**GTE**](https://psx-spx.consoledev.net/geometrytransformationenginegte/) (**G**eometry **T**ransformation **E**ngine) macro. These macros can be found in [SDK.h](../include/Libs/SDK.h) and are always prefixed with `gte_`. The GTE is a specialized coprocessor that is designed to quickly perform complex mathematical operations, which are usually graphics related tasks such as lighting calculations or 3D transformations. If you encounter a GTE macro that isn't present in the repo, you can find the correct macro from the collection [here](https://github.com/Decompollaborate/rabbitizer/blob/fb4ab5e24994a5987c5789983789d8d3dfc7a40f/docs/r3000gte/gte_macros.h)
+If you're decompiling a function and encounter these, then what you've found is a [**GTE**](https://psx-spx.consoledev.net/geometrytransformationenginegte/) (**G**eometry **T**ransformation **E**ngine) macro. These macros can be found in [SDK.h](/include/Libs/SDK.h) and are always prefixed with `gte_`. The GTE is a specialized coprocessor that is designed to quickly perform complex mathematical operations, which are usually graphics related tasks such as lighting calculations or 3D transformations. If you encounter a GTE macro that isn't present in the repo, you can find the correct macro from the [gte_macro collection](https://github.com/Decompollaborate/rabbitizer/blob/fb4ab5e24994a5987c5789983789d8d3dfc7a40f/docs/r3000gte/gte_macros.h).
 
 ### Other Macros
 


### PR DESCRIPTION
GitHub doesn't always like when relative paths are used when embedding images. This fixes the image on the contributing page